### PR TITLE
Нет слов, одни страдания..

### DIFF
--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
@@ -1,0 +1,16 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DiffUtil;
+
+public class BaseListDiffCallback<T extends ListDiffInterface<T>> extends DiffUtil.ItemCallback<T> {
+    @Override
+    public boolean areItemsTheSame(@NonNull T oldItem, @NonNull T newItem) {
+        return oldItem.hashCode() == newItem.hashCode();
+    }
+
+    @Override
+    public boolean areContentsTheSame(@NonNull T oldItem, @NonNull T newItem) {
+        return oldItem.equals(newItem);
+    }
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.DiffUtil;
 public class BaseListDiffCallback<T extends ListDiffInterface<T>> extends DiffUtil.ItemCallback<T> {
     @Override
     public boolean areItemsTheSame(@NonNull T oldItem, @NonNull T newItem) {
-        return oldItem.hashCode() == newItem.hashCode();
+        return oldItem.theSameAs(newItem);
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
@@ -1,0 +1,8 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+public interface ListDiffInterface<T> {
+    public boolean theSameAs(T t);
+
+    public boolean equals(Object o);
+
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
@@ -4,28 +4,27 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.AdapterListUpdateCallback;
+import androidx.recyclerview.widget.AsyncDifferConfig;
+import androidx.recyclerview.widget.AsyncListDiffer;
+import androidx.recyclerview.widget.RecyclerView;
+
 import java.util.List;
 import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.databinding.ItemFilterBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactType;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactTypeUi;
 import ru.yandex.practicum.contacts.utils.model.ContactTypeUtils;
 import ru.yandex.practicum.contacts.utils.model.FilterContactTypeUtils;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.AdapterListUpdateCallback;
-import androidx.recyclerview.widget.AsyncDifferConfig;
-import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
-import androidx.recyclerview.widget.RecyclerView;
-
 public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContactTypeAdapter.ViewHolder> {
 
     private final AsyncListDiffer<FilterContactTypeUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<FilterContactTypeUi>()).build()
     );
 
     private final Consumer<FilterContactTypeUi> clickListener;
@@ -82,25 +81,6 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
                 binding.logo.setVisibility(View.VISIBLE);
                 binding.logo.setImageResource(iconRes);
             }
-        }
-    }
-
-    static class ListDiffCallback extends DiffUtil.ItemCallback<FilterContactTypeUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.getContactType() == newItem.getContactType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return newItem;
         }
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
@@ -2,7 +2,9 @@ package ru.yandex.practicum.contacts.presentation.filter.model;
 
 import androidx.annotation.NonNull;
 
-public class FilterContactTypeUi {
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
+
+public class FilterContactTypeUi implements ListDiffInterface<FilterContactTypeUi> {
 
     private final FilterContactType contactType;
     private final boolean selected;
@@ -18,6 +20,11 @@ public class FilterContactTypeUi {
 
     public boolean isSelected() {
         return selected;
+    }
+
+    @Override
+    public boolean theSameAs(FilterContactTypeUi filterContactTypeUi) {
+        return this.getContactType() == filterContactTypeUi.getContactType();
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
@@ -8,12 +8,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.AdapterListUpdateCallback;
 import androidx.recyclerview.widget.AsyncDifferConfig;
 import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -23,12 +21,13 @@ import java.util.Objects;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemContactBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 
 public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHolder> {
 
     private final AsyncListDiffer<ContactUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<ContactUi>()).build()
     );
 
     @NonNull
@@ -90,25 +89,6 @@ public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHold
                     .fallback(drawable)
                     .error(drawable)
                     .into(binding.contactPhoto);
-        }
-    }
-
-    static class ListDiffCallback extends DiffUtil.ItemCallback<ContactUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.hashCode() == newItem.hashCode();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return newItem;
         }
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
@@ -4,9 +4,9 @@ import androidx.annotation.NonNull;
 
 import java.util.List;
 
-import ru.yandex.practicum.contacts.model.ContactType;
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 
-public class ContactUi {
+public class ContactUi implements ListDiffInterface<ContactUi> {
 
     private final String name;
     private final String phone;
@@ -39,6 +39,10 @@ public class ContactUi {
 
     public List<String> getTypes() {
         return types;
+    }
+    @Override
+    public boolean theSameAs(ContactUi t) {
+        return this.hashCode() == t.hashCode();
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
@@ -5,11 +5,9 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.AdapterListUpdateCallback;
 import androidx.recyclerview.widget.AsyncDifferConfig;
 import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
@@ -17,13 +15,14 @@ import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemSortBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
 public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHolder> {
 
     private final AsyncListDiffer<SortTypeUI> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<SortTypeUI>()).build()
     );
 
     private final Consumer<SortTypeUI> clickListener;
@@ -86,25 +85,6 @@ public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHo
                 default:
                     throw new IllegalArgumentException("Not supported SortType");
             }
-        }
-    }
-
-    static class ListDiffCallback extends DiffUtil.ItemCallback<SortTypeUI> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.getSortType() == newItem.getSortType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return newItem;
         }
     }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
@@ -2,9 +2,10 @@ package ru.yandex.practicum.contacts.presentation.sort;
 
 import androidx.annotation.NonNull;
 
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
-public class SortTypeUI {
+public class SortTypeUI implements ListDiffInterface<SortTypeUI> {
 
     private final SortType sortType;
     private final boolean selected;
@@ -20,6 +21,11 @@ public class SortTypeUI {
 
     public boolean isSelected() {
         return selected;
+    }
+
+    @Override
+    public boolean theSameAs(SortTypeUI t) {
+        return this.getSortType() == t.getSortType();
     }
 
     @Override


### PR DESCRIPTION
Короче, я запутался много раз, логику чуть не уловил 
1. Фактически дженерик-класс будет выглядеть так же, но с некоторыми отличиями:
Класс BaseListDiffCallback должен быть дженерик-классом с ограничением параметра типа на обязательную реализацию интерфейса ListDiffInterface<>. В качестве параметра типа у интерфейса указывается такое же имя, что и у класса.
Класс наследуется от DiffUtil.ItemCallback<>, но в качестве его параметра типа указывается дженерик-тип, но уже без ограничения.
Класс должен переопределять те же самые методы.
Все типы данных, передаваемые в переопределяемые методы, должны быть заменены на дженерик-тип.
Реализацию метода areItemsTheSame() необходимо заменить на реализацию с использованием метода theSameAs() интерфейса ListDiffInterface.
Я тут думал нужно вот так написать:
```
public class BaseListDiffCallback<T extends ListDiffInterface<BaseListDiffCallback>> extends DiffUtil.ItemCallback<T> {
```